### PR TITLE
Fix IE11 issue - missing nodeList.forEach

### DIFF
--- a/src/lib/helpers/youtubeIframeApi.js
+++ b/src/lib/helpers/youtubeIframeApi.js
@@ -314,7 +314,7 @@ var setupYoutubePlayers = function(settings) {
   }
 
   log('debug', 'Setting up YouTube players with the selector "' + youtubeIframeSelector + '"');
-  elements.forEach(function(element) {
+  [].forEach.call(elements, function(element) {
     // setup only those players that have NOT been setup by this extension
     var elementIsNotSetup = element.dataset.launchextSetup !== 'true';
 


### PR DESCRIPTION
In IE, the nodeList type does not have a forEach method, causing an error in the extension when it tries to traverse the list of elements.
This fix uses the forEach method from the Array type instead to resolve.

Fixes yuhui/launchext-youtube-playback#7